### PR TITLE
Add keyring to key import

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -42,6 +42,7 @@
       ansible.builtin.apt_key:
         url: "{{ item }}"
         state: present
+        keyring: "/etc/apt/trusted.gpg.d/virtualbox.gpg"
       loop: "{{ virtualbox_keys }}"
       loop_control:
         label: "{{ item | basename }}"


### PR DESCRIPTION
Prevent the Ubuntu 22.04 warning: `W: https://download.virtualbox.org/virtualbox/debian/dists/jammy/InRelease: Key is stored in legacy trusted.gpg keyring (/etc/apt/trusted.gpg), see the DEPRECATION section in apt-key(8) for details.` showing up when `apt update` is executed after running this role.

---
name: Pull request
about: On ubuntu 22.04, after virtualbox is installed with the role, the way the key is added, it results in warnings for any subsequent `apt update` command which is run on the target machine.

---

**Describe the change**

By adding a specific keyring in /etc/apt/trusted.gpg.d/<specific file> you can avoid this warning.

I'm not entirely sure of this approach, because it looks like it's within a block and could mean we need a different specific file name for each possible gpg key we wish to import. ( I noticed in the vars, there are two, the 2016 key and the non-2016 key). Open to suggestions on how to handle this.

**Testing**
In any case, I made the modification locally and re-ran the role after removing the /etc/apt/trusted.gpg file that was previously generated. The warning is no longer there.

I did not add any specific tests along with this PR, open to suggestions.
